### PR TITLE
Added ResponsibleHook in order to shorten code.

### DIFF
--- a/src/dte/hooksystem/hooks/ResponsibleHook.java
+++ b/src/dte/hooksystem/hooks/ResponsibleHook.java
@@ -1,0 +1,11 @@
+package dte.hooksystem.hooks;
+
+import dte.hooksystem.missingpluginhandlers.MissingPluginHandler;
+
+/**
+ * A hook that decides what to do if the plugin the hook represents is not on the server.
+ */
+public interface ResponsibleHook extends PluginHook
+{
+	MissingPluginHandler getMissingPluginHandler();
+}

--- a/src/dte/hooksystem/service/AbstractHookService.java
+++ b/src/dte/hooksystem/service/AbstractHookService.java
@@ -15,6 +15,7 @@ import org.bukkit.plugin.Plugin;
 import dte.hooksystem.exceptions.HookInitException;
 import dte.hooksystem.exceptions.PluginAlreadyHookedException;
 import dte.hooksystem.hooks.PluginHook;
+import dte.hooksystem.hooks.ResponsibleHook;
 import dte.hooksystem.missingpluginhandlers.MissingPluginHandler;
 
 /**
@@ -65,6 +66,12 @@ public abstract class AbstractHookService implements HookService
 		{
 			throw new HookInitException(hook.getPluginName(), exception);
 		}
+	}
+	
+	@Override
+	public void register(ResponsibleHook responsibleHook) throws PluginAlreadyHookedException, HookInitException 
+	{
+		register(responsibleHook, responsibleHook.getMissingPluginHandler());
 	}
 
 	@Override

--- a/src/dte/hooksystem/service/HookService.java
+++ b/src/dte/hooksystem/service/HookService.java
@@ -11,6 +11,7 @@ import org.bukkit.plugin.Plugin;
 import dte.hooksystem.exceptions.HookInitException;
 import dte.hooksystem.exceptions.PluginAlreadyHookedException;
 import dte.hooksystem.hooks.PluginHook;
+import dte.hooksystem.hooks.ResponsibleHook;
 import dte.hooksystem.missingpluginhandlers.MissingPluginHandler;
 
 public interface HookService extends Iterable<PluginHook>
@@ -35,6 +36,19 @@ public interface HookService extends Iterable<PluginHook>
 	 * @throws HookInitException If there was a problem during the hook's {@code init()} method.
 	 */
 	void register(PluginHook hook, MissingPluginHandler missingPluginHandler) throws PluginAlreadyHookedException, HookInitException;
+	
+	/**
+	 * Registers the provided {@code responsibleHook} as supported by the plugin that owns this service, and tries to initialize it.
+	 * <p>
+	 * If the plugin the hook represents is not on the server, its {@code missingPluginHandler} is executed.
+	 * <p>
+	 * The hook can later be retrieved by its class.
+	 * 
+	 * @param hook The hook to register.
+	 * @throws PluginAlreadyHookedException If this service already has a hook for the {@code hook}'s plugin.
+	 * @throws HookInitException If there was a problem during the hook's {@code init()} method.
+	 */
+	void register(ResponsibleHook responsibleHook) throws PluginAlreadyHookedException, HookInitException;
 
 	/**
 	 * Returns an Optional of the registered hook of the provided {@code hook class}.


### PR DESCRIPTION
The name of the class refers to when the hook's plugin is not on the server, it's responsible of how to react(by offering a MissingPluginHandler).